### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,6 +3,9 @@
 
 name: Validate
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/deejaygraham/deejaygraham.github.io/security/code-scanning/38](https://github.com/deejaygraham/deejaygraham.github.io/security/code-scanning/38)

Add an explicit top-level `permissions` block to `.github/workflows/validate.yml` so the workflow does not inherit potentially broad defaults.

Best single fix (minimal and least disruptive): add:

- `permissions:`
  - `contents: read`

at workflow root (after `name` or before `jobs`). This applies to all jobs in this workflow unless overridden. It preserves current functionality for checkout/validation while satisfying CodeQL and documenting intent.

No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
