### PR TITLE
Potential fix for code scanning alert no. 35: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/a11y-test.yml
+++ b/.github/workflows/a11y-test.yml
@@ -1,7 +1,10 @@
 name: A11y Tests
 on:
   workflow_dispatch:
-    
+
+permissions:
+  contents: read
+
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
Potential fix for [https://github.com/deejaygraham/deejaygraham.github.io/security/code-scanning/35](https://github.com/deejaygraham/deejaygraham.github.io/security/code-scanning/35)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best single fix (without changing functionality) is to add root-level workflow permissions:

- `contents: read`

This applies to all jobs unless overridden and addresses the CodeQL finding directly.  
Edit only `.github/workflows/a11y-test.yml`, adding the `permissions` block after the `on` section and before `jobs`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
